### PR TITLE
Bump version to 1.1.0 and add new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.1.0
+
+- Added binary sensor to show health of volume.
+- Added icon to power button
+- Added icon to NAS temperature
+
 ## v1.0.4
 
 - Removed the verbous logging from the home assistant log.

--- a/custom_components/readynaslocal/manifest.json
+++ b/custom_components/readynaslocal/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "readynaslocal",
   "name": "ReadyNAS",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "documentation": "https://github.com/jasonwragg/home-assistant-readynaslocal",
   "issue_tracker": "https://github.com/jasonwragg/home-assistant-readynaslocal/issues",
   "requirements": [],

--- a/hacs.json
+++ b/hacs.json
@@ -6,5 +6,5 @@
     "codeowners": ["@jasonwragg"],
     "requirements": [],
     "iot_class": "local_polling",
-    "version": "1.0.4"
+    "version": "1.1.0"
   }


### PR DESCRIPTION
Update version number to 1.1.0 and introduce a binary sensor for volume health, along with new icons for the power button and NAS temperature.